### PR TITLE
Fix "Deprecated: Methods with the same name as their class"

### DIFF
--- a/api/libs/api.dbconnect.php
+++ b/api/libs/api.dbconnect.php
@@ -11,7 +11,7 @@ Class DbConnect {
     var $result = false;
     var $error_reporting = false;
 
-    function DbConnect($host, $user, $password, $database, $error_reporting = true, $persistent = false) {
+    public function __construct($host, $user, $password, $database, $error_reporting = true, $persistent = false) {
 
         $this->host = $host;
         $this->user = $user;

--- a/api/libs/api.dbf.php
+++ b/api/libs/api.dbf.php
@@ -75,7 +75,7 @@ class dbf_class {
     var $_hdrsize;           //Length of the header information (offset to 1st record)
     var $_memos;             //The raw memo file (if there is one).
 
-    function dbf_class($filename) {
+    public function __construct($filename) {
         if ( !file_exists($filename)) {
             show_error('Not a valid DBF file !!!'); exit;
         }

--- a/modules/engine/api.calendar.php
+++ b/modules/engine/api.calendar.php
@@ -15,7 +15,7 @@ class calendar{
     var $_events = array();
     var $_highlight = array();
     
-    function calendar($month, $year){
+    public function __construct($month, $year){
         global $system;
         $this->_temp['first_day_stamp'] = mktime(0, 0, 0, $month, 1, $year);
         $this->_temp['first_day_week_pos'] = date('w', $this->_temp['first_day_stamp']);

--- a/modules/engine/api.forum.php
+++ b/modules/engine/api.forum.php
@@ -15,7 +15,7 @@ class forum{
 	var $error = '';
 	var $sort_all = array();
 	
-	function forum(){
+	public function __construct(){
 		if(!$this->loadTopicsData()){
 			return false;
 		}

--- a/modules/engine/api.gallery.php
+++ b/modules/engine/api.gallery.php
@@ -27,7 +27,7 @@ class gallery{
 	var $path = GALLERY_PATH;
 	var $indexes = array();
 
-	function gallery(){
+	public function __construct(){
 		// Load Index files
 		$this->loadIndexFiles();
 	}

--- a/modules/engine/api.linksdb.php
+++ b/modules/engine/api.linksdb.php
@@ -16,7 +16,7 @@ class linksdb{
     var $data = array();
     
     
-    function linksdb($file){
+    public function __construct($file){
         $this->file = $file;
         if(is_readable($file) && $data = unserialize(file_get_contents($file))) $this->data = $data;
         else $this->data = array();

--- a/modules/system/etc.php
+++ b/modules/system/etc.php
@@ -306,7 +306,7 @@ class message{
      * @param boolean $nl2br
      * @return message
      */
-    function message($message, $bbcode_level = 0, $html = false, $nl2br = false){
+    public function __construct($message, $bbcode_level = 0, $html = false, $nl2br = false){
         $this->str = $message;
         $this->nl2br = $nl2br;
         $this->bbcode_level = $bbcode_level;

--- a/modules/system/formsgen.php
+++ b/modules/system/formsgen.php
@@ -10,7 +10,7 @@ class InputForm {
         'file' => '<input type="file" name="%1" value="" />',
     );
 
-    function InputForm($action = '', $method = 'get', $submit = 'Submit', $reset = '', $target = '', $enctype = '', $name = '', $events = '') {
+    public function __construct($action = '', $method = 'get', $submit = 'Submit', $reset = '', $target = '', $enctype = '', $name = '', $events = '') {
         $this->options = array(
             'action' => $action,
             'method' => $method,

--- a/modules/system/system.php
+++ b/modules/system/system.php
@@ -27,7 +27,7 @@ class rcms_system extends rcms_user {
 	var $logging_gz = true;
 	var $url = '';
 
-	function rcms_system($language_select_form = '', $skin_select_form = ''){
+	public function __construct($language_select_form = '', $skin_select_form = ''){
 		global $lang;
 		
 		// Loading configuration

--- a/modules/system/tar.php
+++ b/modules/system/tar.php
@@ -9,7 +9,7 @@ class tar {
 	var $numFiles;
 	var $numDirectories;
 
-	function tar() {
+	public function __construct() {
 		return true;
 	}
 

--- a/modules/system/user-classes.php
+++ b/modules/system/user-classes.php
@@ -100,7 +100,7 @@ class rcms_user_cache{
 	var $cache_filename = 'users.cache.dat';
 	var $cache = array();
 
-	function rcms_user_cache(){
+	public function __construct(){
 		if(!is_file(DATA_PATH . $this->cache_filename)) {
 			$this->cache = array();
 		} else {


### PR DESCRIPTION
Минимально требуемая версия PHP 4
http://php.net/manual/ru/migration70.deprecated.php

 Changes to be committed:
	modified:   api/libs/api.dbconnect.php
	modified:   api/libs/api.dbf.php
	modified:   modules/engine/api.calendar.php
	modified:   modules/engine/api.forum.php
	modified:   modules/engine/api.gallery.php
	modified:   modules/engine/api.linksdb.php
	modified:   modules/system/etc.php
	modified:   modules/system/formsgen.php
	modified:   modules/system/system.php
	modified:   modules/system/tar.php
	modified:   modules/system/user-classes.php